### PR TITLE
Updating enumerations to match Apple's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ class Guideline {
 
 ### 1.1 Enumerations
 
-Use UpperCamelCase for enumeration values:
+Use lowerCamelCase for enumeration values:
 
 ```swift
 enum Shape {
-    case Rectangle
-    case Square
-    case Triangle
-    case Circle
+    case rectangle
+    case square
+    case trianle
+    case circle
 }
 ```
 


### PR DESCRIPTION
In Swift 3 UpperCamelCase has been replaced with lowerCamelCase for enumerations. Could be a good idea to follow the same standard to avoid inconsistency.
